### PR TITLE
#463 Po aktualizaci zůstávala v aplikaci stará data

### DIFF
--- a/app/src/main/java/cz/jaro/dpmcb/data/SpojeRepository.kt
+++ b/app/src/main/java/cz/jaro/dpmcb/data/SpojeRepository.kt
@@ -732,6 +732,11 @@ class SpojeRepository(
             .toList()
             .first { date.isThisTableNowUsed(it.first) }
             .second
+
+    fun reset() {
+        sequencesMap.clear()
+        tablesMap.clear()
+    }
 }
 
 private infix fun List<RunsFromTo>.anyAre(type: TimeCodeType) = any { it.type == type }

--- a/app/src/main/java/cz/jaro/dpmcb/ui/loading/LoadingViewModel.kt
+++ b/app/src/main/java/cz/jaro/dpmcb/ui/loading/LoadingViewModel.kt
@@ -294,6 +294,7 @@ class LoadingViewModel(
             }
 
             db.clearAllTables()
+            repo.reset()
 
             _state.update {
                 "Aktualizování jízdních řádů.\nTato akce může trvat několik minut.\nProsíme, nevypínejte aplikaci.\nStahování dat (2/5)" to 0F
@@ -354,6 +355,8 @@ class LoadingViewModel(
             _state.update {
                 "Aktualizování jízdních řádů.\nTato akce může trvat několik minut.\nProsíme, nevypínejte aplikaci.\nStahování aktualizačního balíčku (1/?)" to 0F
             }
+
+            repo.reset()
 
             val sequencesRef = storage.reference.child("kurzy.json")
             val diagramRef = storage.reference.child("schema.pdf")


### PR DESCRIPTION
Reset SpojeRepository's sequencesMap and tablesMap when updating timetables to ensure fresh data is used.